### PR TITLE
Fix for _Could not load icon '529Renew-19.png' specified in 'action'_ bug

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,10 +37,10 @@
     "unlimitedStorage"
   ],
   "icons" : {
-  	"16" : "529Renew-16.png",
-  	"19" : "529Renew-19.png",
-  	"48" : "529Renew-48.png",
-  	"128" : "529Renew-128.png"
+  	"16" : "529renew-16.png",
+  	"19" : "529renew-19.png",
+  	"48" : "529renew-48.png",
+  	"128" : "529renew-128.png"
   },
   "web_accessible_resources": [
 	{
@@ -54,7 +54,7 @@
   ],
   "action":
   {
-  	"default_icon" : "529Renew-19.png",
+  	"default_icon" : "529renew-19.png",
   	"default_title" : "View matches in 529Renew",
     "default_popup" : "popup529.html"
   },


### PR DESCRIPTION
It has been noted in the Chrome Web Store comments that the error: _Could not load icon '529Renew-19.png' specified in 'action'_ can sometimes be received when attempting to install __529renew__. I recognised this error when I received it today: it is due to the filename casing not matching within the referencing code.

In this case, the logo files are all named lowercase, but they are referenced with a capital 'R' in the manifest file.

This mismatch makes no difference for Windows and case-insensitive filing systems but throws an error on Linux and other case-sensitive systems.

The fix is as simple as setting the 'R' to lowercase within the manifest file.